### PR TITLE
Support output to alternative directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ It's unlikely that any of the configurations need to be changed for the majority
 
 Your plugin settings are written in the `src/components/settings.json`. This is converted to YAML as part of the bundling process.
 
+Output is written to the `dist` folder by default. This can be changed by setting the `STASH_PLUGIN_DEST` environment variable to the desired output directory.
+
 ## Using the Plugin API
 
 The Stash plugin API can be accessed via `window.pluginApi` (see `src/main.tsx` for an example). The API exposes several libraries used by Stash, which are referenced as peer dependencies by this template. They can be imported into your files as normal, but will not be bundled into the plugin in order to reduce output size and avoid conflicts.

--- a/generateYaml.mjs
+++ b/generateYaml.mjs
@@ -3,6 +3,7 @@ import pluginSettings from "./src/settings.json" with { type: "json" }
 import * as pkg from "./package.json" with { type: "json" };
 import fs from 'fs';
 
+const dest = process.env.STASH_PLUGIN_DEST ?? "dist";
 const filename =  pkg.default.name + ".yml"
 
 // Only import the entry file. If you there are multiple entrypoints, you'll
@@ -12,7 +13,7 @@ const jsFiles = [pkg.default.name + ".js"]
 // Check if CSS has been generated
 const cssFiles = []
 
-fs.readdir('dist/', (_err, files) => {
+fs.readdir(dest + '/', (_err, files) => {
   files.forEach(file => {
     const isCss = file.split(".")[file.split(".").length -1] === "css"
     if (isCss) cssFiles.push(file)
@@ -31,6 +32,6 @@ const json = {
   settings: pluginSettings
 }
 
-writeYamlFile('dist/' + filename, json).then(() => {
-  console.log('Generated source file "' + filename + '".')
+writeYamlFile(dest + '/' + filename, json).then(() => {
+  console.log('Generated source file "' + dest + '/' + filename + '".')
 })

--- a/rollup.config.common.mjs
+++ b/rollup.config.common.mjs
@@ -7,6 +7,8 @@ import replace from "@rollup/plugin-replace";
 import typescript from "@rollup/plugin-typescript";
 import * as pkg from "./package.json" with { type: "json" };
 
+const dest = process.env.STASH_PLUGIN_DEST ?? "dist";
+
 const pluginID = pkg.default.name;
 
 // Replace require imports with Plugin API library references
@@ -41,17 +43,17 @@ export default {
   input: "src/main.tsx",
   output: {
     banner,
-    file: "dist/" + pluginID + ".js",
+    file: dest + "/" + pluginID + ".js",
     format: "cjs",
   },
   plugins: [
     commonjs(),
     copy({
       targets: [
-        { src: "src/source.yml", dest: "dist", rename: pluginID + ".yml" },
+        { src: "src/source.yml", dest, rename: pluginID + ".yml" },
       ],
     }),
-    del({ targets: "dist" }),
+    del({ targets: dest, force: true }),
     nodeResolve(),
     peerDepsExternal(),
     replace({


### PR DESCRIPTION
Adds support for outputting to a different directory than `dist`. Setting `STASH_PLUGIN_DEST` will make the build and watch scripts output to that directory instead.